### PR TITLE
Refactor Dockerfile and pre-install rtt_ros2_integration and rtt_ros2_common_interfaces

### DIFF
--- a/ros2/ubuntu/Dockerfile
+++ b/ros2/ubuntu/Dockerfile
@@ -1,44 +1,85 @@
-## Provide Orocos Toolchain (RTT/OCL) on top of the official ROS 2 docker images.
-ARG OROCOS_TOOLCHAIN_BRANCH=ros2
+## Provide Orocos Toolchain (RTT/OCL) and rtt_ros2_integration overlay workspace on top of the
+## official ROS 2 docker images.
+
 ARG ROS_DISTRO
 ARG UBUNTU_DISTRO
 
-## Stage deps: install additional Orocos Toolchain (with CORBA) dependencies
-FROM ros:${ROS_DISTRO}-ros-base-${UBUNTU_DISTRO} AS deps
-RUN apt-get update && apt-get install -y \
-    libboost-all-dev \
-    liblua5.1-0-dev \
-    libncurses5-dev \
-    libnetcdf-dev \
-    libreadline-dev \
-    libxml-xpath-perl \
-    omniorb omniidl omniorb-idl omniorb-nameserver libomniorb4-dev \
-    ruby bundler \
-    $([[ "$UBUNTU_DISTRO" != "focal" ]] && echo "ruby-facets") \
-    && rm -rf /var/lib/apt/lists/*
-
-## Stage build: clone and build orocos_toolchain with colcon
-FROM deps AS build
-ARG OROCOS_TOOLCHAIN_BRANCH
-RUN git clone --recursive https://github.com/orocos-toolchain/orocos_toolchain.git -b ${OROCOS_TOOLCHAIN_BRANCH} /build/orocos_toolchain
-RUN cd /build/orocos_toolchain \
-    && . /opt/ros/${ROS_DISTRO}/setup.sh \
-    && DESTDIR=/stage colcon build \
-        --event-handlers console_direct+ \
-        --install-base /opt/ros/${ROS_DISTRO} \
-        --merge-install \
-        --cmake-args \
-            \ -DCMAKE_BUILD_TYPE=Release \
-            \ -DCMAKE_FIND_ROOT_PATH=/stage \
-            \ -DCMAKE_PREFIX_PATH=/opt/ros/${ROS_DISTRO} \
-            \ -DENABLE_CORBA=ON \
-            \ -DCORBA_IMPLEMENTATION=OMNIORB \
-            \ -DOROCOS_INSTALL_INTO_PREFIX_ROOT=ON
-
-## Stage deploy: copy the install-space to /opt/ros/${ROS_DISTRO} as a
-## new image layer based on deps
-FROM deps AS deploy
-COPY --from=build /stage/opt/ros/${ROS_DISTRO} /opt/ros/${ROS_DISTRO}
+## *************************************************************************************************
+## Stage base: prepare build environment
+## *************************************************************************************************
+FROM ros:${ROS_DISTRO}-ros-base-${UBUNTU_DISTRO} AS base
 
 # default config file for colcon
 COPY .colcon/defaults.yaml /root/.colcon/defaults.yaml
+
+# add custom rosdep rule file and update rosdep database
+COPY prereqs.yaml /etc/ros/rosdep/
+RUN echo "yaml file:///etc/ros/rosdep/prereqs.yaml" > /etc/ros/rosdep/sources.list.d/10-custom.list
+RUN rosdep update
+
+# setup new entrypoint and default command
+COPY orocos_entrypoint.sh /orocos_entrypoint.sh
+ENTRYPOINT [ "/orocos_entrypoint.sh" ]
+CMD [ "bash" ]
+
+## *************************************************************************************************
+## Stage orocos_toolchain: clone, build and install Orocos Toolchain using CMake (with CORBA)
+## *************************************************************************************************
+FROM base AS orocos_toolchain
+
+COPY orocos_toolchain.repos /build/
+RUN vcs import --recursive /build < /build/orocos_toolchain.repos \
+    && cd /build/orocos_toolchain \
+    && . /opt/ros/${ROS_DISTRO}/local_setup.sh \
+    #
+    # Install dependencies with rosdep
+    && apt-get update \
+    && apt-get install -y ruby \
+    && rosdep install -y --from-path . --ignore-src \
+    && rm -rf /var/lib/apt/lists/* \
+    #
+    # Build the workspace
+    && colcon build \
+        --event-handlers console_direct+ \
+        --install-base /opt/orocos/${ROS_DISTRO} \
+        --merge-install \
+        --cmake-args \
+            \ -DBUILD_TESTING=OFF \
+            \ -DCMAKE_BUILD_TYPE=Release \
+            \ -DENABLE_CORBA=ON \
+            \ -DCORBA_IMPLEMENTATION=OMNIORB \
+            \ -DOROCOS_INSTALL_INTO_PREFIX_ROOT=ON \
+    #
+    # Cleanup
+    && rm -rf /build
+
+## *************************************************************************************************
+## Stage overlay: clone, build and install overlay workspaces to /opt/ros/${ROS_DISTRO}
+## *************************************************************************************************
+FROM orocos_toolchain AS overlay
+
+COPY overlay.repos /build/
+RUN mkdir -p /build/src \
+    && cd /build \
+    && vcs import --recursive src < overlay.repos \
+    && . /opt/ros/${ROS_DISTRO}/local_setup.sh \
+    && . /opt/orocos/${ROS_DISTRO}/local_setup.sh \
+    #
+    # Install dependencies with rosdep
+    && apt-get update \
+    && ROS_PACKAGE_PATH=/opt/orocos/${ROS_DISTRO}/share:/opt/ros/${ROS_DISTRO}/share \
+           rosdep install -y --from-path . --ignore-src \
+    && rm -rf /var/lib/apt/lists/* \
+    #
+    # Build the workspace
+    && colcon build \
+        --event-handlers console_direct+ \
+        --install-base /opt/orocos/${ROS_DISTRO} \
+        --merge-install \
+        --parallel-workers 2 \
+        --cmake-args \
+            \ -DBUILD_TESTING=OFF \
+            \ -DCMAKE_BUILD_TYPE=Release \
+    #
+    # Cleanup
+    && rm -rf /build

--- a/ros2/ubuntu/Dockerfile
+++ b/ros2/ubuntu/Dockerfile
@@ -3,6 +3,7 @@
 
 ARG ROS_DISTRO
 ARG UBUNTU_DISTRO
+ARG MAKEFLAGS=""
 
 ## *************************************************************************************************
 ## Stage base: prepare build environment
@@ -57,6 +58,7 @@ RUN vcs import --recursive /build < /build/orocos_toolchain.repos \
 ## Stage overlay: clone, build and install overlay workspaces to /opt/ros/${ROS_DISTRO}
 ## *************************************************************************************************
 FROM orocos_toolchain AS overlay
+ARG MAKEFLAGS
 
 COPY overlay.repos /build/src/
 RUN vcs import --recursive /build/src < /build/src/overlay.repos \
@@ -71,7 +73,8 @@ RUN vcs import --recursive /build/src < /build/src/overlay.repos \
     && rm -rf /var/lib/apt/lists/* \
     #
     # Build the workspace
-    && colcon build \
+    && MAKEFLAGS="${MAKEFLAGS}" \
+       colcon build \
         --event-handlers console_direct+ \
         --install-base /opt/orocos/${ROS_DISTRO} \
         --merge-install \

--- a/ros2/ubuntu/Dockerfile
+++ b/ros2/ubuntu/Dockerfile
@@ -3,6 +3,10 @@
 
 ARG ROS_DISTRO
 ARG UBUNTU_DISTRO
+
+# optional arguments required for building on systems with limited CPU or memory resources
+# or to customize the build
+ARG COLCON_ARGS=""
 ARG MAKEFLAGS=""
 
 ## *************************************************************************************************
@@ -27,6 +31,8 @@ CMD [ "bash" ]
 ## Stage orocos_toolchain: clone, build and install Orocos Toolchain using CMake (with CORBA)
 ## *************************************************************************************************
 FROM base AS orocos_toolchain
+ARG COLCON_ARGS
+ARG MAKEFLAGS
 
 COPY orocos_toolchain.repos /build/
 RUN vcs import --recursive /build < /build/orocos_toolchain.repos \
@@ -40,7 +46,8 @@ RUN vcs import --recursive /build < /build/orocos_toolchain.repos \
     && rm -rf /var/lib/apt/lists/* \
     #
     # Build the workspace
-    && colcon build \
+    && MAKEFLAGS="${MAKEFLAGS}" \
+       colcon build \
         --event-handlers console_direct+ \
         --install-base /opt/orocos/${ROS_DISTRO} \
         --merge-install \
@@ -50,6 +57,7 @@ RUN vcs import --recursive /build < /build/orocos_toolchain.repos \
             \ -DENABLE_CORBA=ON \
             \ -DCORBA_IMPLEMENTATION=OMNIORB \
             \ -DOROCOS_INSTALL_INTO_PREFIX_ROOT=ON \
+        ${COLCON_ARGS} \
     #
     # Cleanup
     && rm -rf /build
@@ -58,6 +66,7 @@ RUN vcs import --recursive /build < /build/orocos_toolchain.repos \
 ## Stage overlay: clone, build and install overlay workspaces to /opt/ros/${ROS_DISTRO}
 ## *************************************************************************************************
 FROM orocos_toolchain AS overlay
+ARG COLCON_ARGS
 ARG MAKEFLAGS
 
 COPY overlay.repos /build/src/
@@ -81,6 +90,7 @@ RUN vcs import --recursive /build/src < /build/src/overlay.repos \
         --cmake-args \
             \ -DBUILD_TESTING=OFF \
             \ -DCMAKE_BUILD_TYPE=Release \
+        ${COLCON_ARGS} \
     #
     # Cleanup
     && rm -rf /build

--- a/ros2/ubuntu/Dockerfile
+++ b/ros2/ubuntu/Dockerfile
@@ -58,10 +58,9 @@ RUN vcs import --recursive /build < /build/orocos_toolchain.repos \
 ## *************************************************************************************************
 FROM orocos_toolchain AS overlay
 
-COPY overlay.repos /build/
-RUN mkdir -p /build/src \
+COPY overlay.repos /build/src/
+RUN vcs import --recursive /build/src < /build/src/overlay.repos \
     && cd /build \
-    && vcs import --recursive src < overlay.repos \
     && . /opt/ros/${ROS_DISTRO}/local_setup.sh \
     && . /opt/orocos/${ROS_DISTRO}/local_setup.sh \
     #
@@ -76,7 +75,6 @@ RUN mkdir -p /build/src \
         --event-handlers console_direct+ \
         --install-base /opt/orocos/${ROS_DISTRO} \
         --merge-install \
-        --parallel-workers 2 \
         --cmake-args \
             \ -DBUILD_TESTING=OFF \
             \ -DCMAKE_BUILD_TYPE=Release \

--- a/ros2/ubuntu/hooks/build
+++ b/ros2/ubuntu/hooks/build
@@ -7,7 +7,7 @@ ROS_DISTRO=${DOCKER_TAG%%-*}
 UBUNTU_DISTRO=${DOCKER_TAG##*-}
 
 # Build and push the stage orocos_toolchain first.
-# Caching should make sure that the actual build step only rebuilds the final stage overlay.
+# Caching should make sure that the subsequent build step only builds the final stage overlay.
 docker build \
   -t orocos/ros2-ci:${DOCKER_TAG} \
   --build-arg ROS_DISTRO=${ROS_DISTRO} \
@@ -16,9 +16,11 @@ docker build \
   .
 docker push orocos/ros2-ci:${DOCKER_TAG}
 
-# Only then build the final stage. It will be pushed by Docker Hub.
+# Build the final stage. It will be pushed implicitly by Docker Hub.
+# Note: The number of parallel jobs is limited to 1 because of limited memory resources (MAKEFLAGS).
 docker build \
   -t orocos/ros2:${DOCKER_TAG} \
   --build-arg ROS_DISTRO=${ROS_DISTRO} \
   --build-arg UBUNTU_DISTRO=${UBUNTU_DISTRO} \
+  --build-arg MAKEFLAGS="-j1" \
   .

--- a/ros2/ubuntu/hooks/build
+++ b/ros2/ubuntu/hooks/build
@@ -2,25 +2,35 @@
 # Build hook for Docker Hub.
 # See https://docs.docker.com/docker-hub/builds/advanced/.
 
+# abort on error
+set -e
+
 #DOCKER_TAG=eloquent-ros-base-bionic
 ROS_DISTRO=${DOCKER_TAG%%-*}
 UBUNTU_DISTRO=${DOCKER_TAG##*-}
 
-# Build and push the stage orocos_toolchain first.
-# Caching should make sure that the subsequent build step only builds the final stage overlay.
-docker build \
-  -t orocos/ros2-ci:${DOCKER_TAG} \
+# Build arguments
+# Note: We do not allow to run colcon executors in parallel (COLCON_ARGS) and limit the number of
+# parallel make jobs is limited to 1 (MAKEFLAGS) because of limited memory resources for automated
+# builds (https://success.docker.com/article/what-are-the-current-resource-limits-placed-on-automated-builds).
+BUILD_ARGS=(
   --build-arg ROS_DISTRO=${ROS_DISTRO} \
   --build-arg UBUNTU_DISTRO=${UBUNTU_DISTRO} \
-  --target orocos_toolchain \
-  .
-docker push orocos/ros2-ci:${DOCKER_TAG}
+  --build-arg COLCON_ARGS="--executor sequential" \
+  --build-arg MAKEFLAGS="-j1" \
+)
 
-# Build the final stage. It will be pushed implicitly by Docker Hub.
-# Note: The number of parallel jobs is limited to 1 because of limited memory resources (MAKEFLAGS).
+# Build the final stage first. It will be pushed implicitly by Docker Hub.
 docker build \
   -t orocos/ros2:${DOCKER_TAG} \
-  --build-arg ROS_DISTRO=${ROS_DISTRO} \
-  --build-arg UBUNTU_DISTRO=${UBUNTU_DISTRO} \
-  --build-arg MAKEFLAGS="-j1" \
+  "${BUILD_ARGS[@]}" \
   .
+
+# Build and push the intermediate stage orocos_toolchain as orocos/ros2-ci:${DOCKER_TAGS}
+# (for ROS integration CI). Caching should make sure that none of the build steps executes again.
+docker build \
+  -t orocos/ros2-ci:${DOCKER_TAG} \
+  --target orocos_toolchain \
+  "${BUILD_ARGS[@]}" \
+  .
+docker push orocos/ros2-ci:${DOCKER_TAG}

--- a/ros2/ubuntu/hooks/build
+++ b/ros2/ubuntu/hooks/build
@@ -6,4 +6,19 @@
 ROS_DISTRO=${DOCKER_TAG%%-*}
 UBUNTU_DISTRO=${DOCKER_TAG##*-}
 
-docker build -t $IMAGE_NAME --build-arg ROS_DISTRO=${ROS_DISTRO} --build-arg UBUNTU_DISTRO=${UBUNTU_DISTRO} .
+# Build and push the stage orocos_toolchain first.
+# Caching should make sure that the actual build step only rebuilds the final stage overlay.
+docker build \
+  -t orocos/ros2-ci:${DOCKER_TAG} \
+  --build-arg ROS_DISTRO=${ROS_DISTRO} \
+  --build-arg UBUNTU_DISTRO=${UBUNTU_DISTRO} \
+  --target orocos_toolchain \
+  .
+docker push orocos/ros2-ci:${DOCKER_TAG}
+
+# Only then build the final stage. It will be pushed by Docker Hub.
+docker build \
+  -t orocos/ros2:${DOCKER_TAG} \
+  --build-arg ROS_DISTRO=${ROS_DISTRO} \
+  --build-arg UBUNTU_DISTRO=${UBUNTU_DISTRO} \
+  .

--- a/ros2/ubuntu/orocos_entrypoint.sh
+++ b/ros2/ubuntu/orocos_entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# Setup ros2 and orocos environment
+source "/opt/ros/$ROS_DISTRO/setup.sh"
+[ -d "/opt/orocos/$ROS_DISTRO" ] && source "/opt/orocos/$ROS_DISTRO/local_setup.sh"
+
+# Append commands to setup ros2 and orocos environment to ~/.bashrc.
+# This is only relevant if the command to be executed ("$@") is an interactive bash shell.
+# Or for later `docker exec -it bash`.
+# It is not sufficient to source bash-specific setup scripts here, because bash is executed as
+# a new process. Aliases, command-line completion etc. configured here would have no effect.
+if ! grep -q '# setup ros2 and orocos environment' ~/.bashrc >/dev/null; then
+  cat >>~/.bashrc <<'EOF'
+
+# setup ros2 and orocos environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+[ -d "/opt/orocos/$ROS_DISTRO" ] && source "/opt/orocos/$ROS_DISTRO/local_setup.bash"
+EOF
+fi
+
+exec "$@"

--- a/ros2/ubuntu/orocos_toolchain.repos
+++ b/ros2/ubuntu/orocos_toolchain.repos
@@ -1,0 +1,5 @@
+repositories:
+  orocos_toolchain:
+    type: git
+    url: https://github.com/orocos-toolchain/orocos_toolchain.git
+    version: ros2

--- a/ros2/ubuntu/overlay.repos
+++ b/ros2/ubuntu/overlay.repos
@@ -1,0 +1,9 @@
+repositories:
+  rtt_ros2_integration:
+    type: git
+    url: https://github.com/orocos/rtt_ros2_integration.git
+    version: master
+  rtt_ros2_common_interfaces:
+    type: git
+    url: https://github.com/orocos/rtt_ros2_common_interfaces.git
+    version: master

--- a/ros2/ubuntu/prereqs.yaml
+++ b/ros2/ubuntu/prereqs.yaml
@@ -1,0 +1,10 @@
+metaruby:
+  debian:
+    gem: metaruby
+  ubuntu:
+    gem: metaruby
+utilrb:
+  debian:
+    gem: utilrb
+  ubuntu:
+    gem: utilrb

--- a/ros2/ubuntu/prereqs.yaml
+++ b/ros2/ubuntu/prereqs.yaml
@@ -1,3 +1,11 @@
+# Package ruby-facets does not exist anymore since Ubuntu Focal.
+# Use gem instead.
+facets:
+  ubuntu:
+    focal:
+      gem: facets
+
+# Use metaruby and utilrb from rubygems.org.
 metaruby:
   debian:
     gem: metaruby

--- a/ros2/ubuntu/prereqs.yaml
+++ b/ros2/ubuntu/prereqs.yaml
@@ -2,6 +2,7 @@
 # Use gem instead.
 facets:
   ubuntu:
+    '*': ruby-facets
     focal:
       gem: facets
 


### PR DESCRIPTION
This is an alternative to #2. The goal is to provide a Docker image with [rtt_ros2_integration](https://github.com/orocos/rtt_ros2_integration) and [rtt_ros2_common_interfaces](https://github.com/orocos/rtt_ros2_common_interfaces) preinstalled in an overlay workspace.

- Instead of adding a new `Dockerfile` in `ros2_integration/ubuntu` as suggested in #2, the existing `Dockerfile` in `ros2/ubuntu` is modified. At the end both images are about Orocos/ROS integration.
- URLs and branches of source repos are listed in a [.repo file](https://index.ros.org/doc/ros2/Installation/Maintaining-a-Source-Checkout/) and cloned using [vcstool](https://github.com/dirk-thomas/vcstool).
- Dependencies are installed using [rosdep](https://wiki.ros.org/rosdep) and do not have to be listed manually in the `Dockerfile` anymore. A custom yaml file `prereqs.yaml` lists Ruby dependencies which are not yet in the official [rosdep database](https://github.com/ros/rosdistro/tree/master/rosdep). Those are for [orogen](https://github.com/orocos-toolchain/orogen) only, which at the moment is not installed in the `ros2` branch of [orocos_toolchain](https://github.com/orocos-toolchain/orocos_toolchain) when using cmake/colcon. This approach has been taken from [the ros2/nightly builds at osrf/docker_images](https://github.com/osrf/docker_images/blob/master/ros2/nightly/nightly/prereqs.yaml).
- By stopping at target `orocos_toolchain` in a [multi-stage build](https://docs.docker.com/develop/develop-images/multistage-build/) (`docker build --target orocos_toolchain [...]`), one can still create an image with only the core toolchain packages preinstalled, without the overlay workspace.
- Drop the installation with `DESTDIR` at workspace level. For installing individual packages `DESTDIR` works fine, but at workspace level it requires "hacks" with potential side effects, like setting the `CMAKE_FIND_ROOT_PATH`, `PYTHONPATH`, `PKG_CONFIG_PATH` variables to the staged installation directory, such that packages can find the artifacts of others that have been built before, but not yet installed to the final destination. The downside is that almost all commands to clone, install new system dependencies, build and install a workspace have to be combined in a single `RUN` command, such that the resulting new layer only contains the new dependencies and the installed artifacts, but not sources or build artifacts.
- The installation prefix was changed to `/opt/orocos/${ROS_DISTRO}`. Unfortunately installing packages to `/opt/ros/${ROS_DISTRO}` with colcon is not officially supported and it has negative side effects (https://answers.ros.org/question/314019/how-to-install-colcon-packages-into-system-workspace/). Doing so overwrites the setup files generated by [ament_cmake](https://github.com/ament/ament_cmake).
- A new `orocos_entrypoint.sh` script takes care of sourcing both workspaces, `/opt/ros/${ROS_DISTRO}` and `/opt/orocos/${ROS_DISTRO}` and also appends the necessary commands to `~/.bashrc`. The latter is required for bash-specific extensions to work in the docker container, e.g. tab completion for the `ros2` command. Sourcing the `.bash` setup files in the entrypoint itself, before `bash` is executed as a new process, is useless (as done in [osrf/docker_images](https://github.com/osrf/docker_images/blob/5ee4389841e72474698cd2dce7378b54e3717459/ros/eloquent/ubuntu/bionic/ros-core/ros_entrypoint.sh)).
- Added `--parallel-workers 2` because building typekits and transport libraries is quite memory and CPU intensive and freezes the system with the default number of build jobs, i.e. the number of CPU cores.

I am not sure yet whether the final image (up to stage `overlay`) works for CI of [rtt_ros2_integration](https://github.com/orocos/rtt_ros2_integration) and [rtt_ros2_common_interfaces](https://github.com/orocos/rtt_ros2_common_interfaces) itself, if `/opt/orocos/${ROS_DISTRO}` already has installed versions of the same packages. There could be side effects due to mixing of different versions of the packages, e.g. when testing pull requests. I think it is necessary to provide two versions of the image at https://hub.docker.com/repository/docker/orocos/ros2 for each ROS distro, one with `rtt_ros2_integration` preinstalled and one which stops at stage `orocos_toolchain`. I will test it with automated builds now.

If the approach taken here is accepted, it should also be applied to #1 for ROS 1 images.