### PR TITLE
ros2/ubuntu: add COLCON_IGNORE marker in rtt_ros2_integration/tests folder

### DIFF
--- a/ros2/ubuntu/Dockerfile
+++ b/ros2/ubuntu/Dockerfile
@@ -75,6 +75,9 @@ RUN vcs import --recursive /build/src < /build/src/overlay.repos \
     && . /opt/ros/${ROS_DISTRO}/local_setup.sh \
     && . /opt/orocos/${ROS_DISTRO}/local_setup.sh \
     #
+    # Ignore test packages
+    && touch src/rtt_ros2_integration/tests/COLCON_IGNORE \
+    #
     # Install dependencies with rosdep
     && apt-get update \
     && ROS_PACKAGE_PATH=/opt/orocos/${ROS_DISTRO}/share:/opt/ros/${ROS_DISTRO}/share \


### PR DESCRIPTION
Even with `-DBUILD_TESTING=OFF` colcon tracks which packages have been built and the generated top-level setup files expect some per-package setup files in the respective `share/<package>` directory. But those files are not installed if testing is disabled and the `ament_package()` CMake macro is not invoked (e.g. [rtt_ros2_params_tests/CMakeLists.txt](https://github.com/orocos/rtt_ros2_integration/blob/2fe88749a90f7d33051ea58d5d5a0f18853777ff/tests/rtt_ros2_params_tests/CMakeLists.txt#L4-L11)).

Without this patch:
```sh
$ docker run -it orocos/ros2:eloquent-ros-base-bionic bash
not found: "/opt/orocos/eloquent/share/rtt_ros2_idl_tests/local_setup.sh"
not found: "/opt/orocos/eloquent/share/rtt_ros2_params_tests/local_setup.sh"
not found: "/opt/orocos/eloquent/share/rtt_ros2_services_tests/local_setup.sh"
not found: "/opt/orocos/eloquent/share/rtt_ros2_test_msgs/local_setup.sh"
not found: "/opt/orocos/eloquent/share/rtt_ros2_tests/local_setup.sh"
not found: "/opt/orocos/eloquent/share/rtt_ros2_topics_tests/local_setup.sh"
not found: "/opt/orocos/eloquent/share/rtt_ros2_idl_tests/local_setup.bash"
not found: "/opt/orocos/eloquent/share/rtt_ros2_params_tests/local_setup.bash"
not found: "/opt/orocos/eloquent/share/rtt_ros2_services_tests/local_setup.bash"
not found: "/opt/orocos/eloquent/share/rtt_ros2_test_msgs/local_setup.bash"
not found: "/opt/orocos/eloquent/share/rtt_ros2_tests/local_setup.bash"
not found: "/opt/orocos/eloquent/share/rtt_ros2_topics_tests/local_setup.bash"
root@22836e1caaee:/#
```